### PR TITLE
Remove build dependency to safe_teleop_base from safe_teleop_stage and safe_teleop_pr2

### DIFF
--- a/safe_teleop_pr2/CMakeLists.txt
+++ b/safe_teleop_pr2/CMakeLists.txt
@@ -1,8 +1,7 @@
 cmake_minimum_required(VERSION 2.8.3)
 project(safe_teleop_pr2)
 
-find_package(catkin REQUIRED COMPONENTS
-  safe_teleop_base pr2_teleop joy)
+find_package(catkin REQUIRED COMPONENTS)
 catkin_package(CATKIN_DEPENDS safe_teleop_base pr2_teleop joy)
 
 install(DIRECTORY scripts launch config

--- a/safe_teleop_pr2/package.xml
+++ b/safe_teleop_pr2/package.xml
@@ -8,9 +8,6 @@
   <license>BSD</license>
   <url>http://ros.org/wiki/safe_teleop_pr2</url>
   <buildtool_depend>catkin</buildtool_depend>
-  <build_depend>safe_teleop_base</build_depend>
-  <build_depend>pr2_teleop</build_depend>
-  <build_depend>joy</build_depend>
   <run_depend>safe_teleop_base</run_depend>
   <run_depend>pr2_teleop</run_depend>
   <run_depend>joy</run_depend>

--- a/safe_teleop_stage/CMakeLists.txt
+++ b/safe_teleop_stage/CMakeLists.txt
@@ -1,9 +1,7 @@
 cmake_minimum_required(VERSION 2.8.3)
 project(safe_teleop_stage)
 
-find_package(catkin REQUIRED COMPONENTS
-  safe_teleop_base joy
-  )
+find_package(catkin REQUIRED COMPONENTS)
 catkin_package(CATKIN_DEPENDS safe_teleop_base joy)
 
 install(DIRECTORY launch config
@@ -11,4 +9,3 @@ install(DIRECTORY launch config
   ${CATKIN_PACKAGE_SHARE_DESTINATION}
   USE_SOURCE_PERMISSIONS
   )
-

--- a/safe_teleop_stage/package.xml
+++ b/safe_teleop_stage/package.xml
@@ -8,9 +8,6 @@
   <license>BSD</license>
   <url>http://ros.org/wiki/safe_teleop_stage</url>
   <buildtool_depend>catkin</buildtool_depend>
-  <build_depend>safe_teleop_base</build_depend>
-  <build_depend>stage</build_depend>
-  <build_depend>joy</build_depend>
   <run_depend>safe_teleop_base</run_depend>
   <run_depend>stage</run_depend>
   <run_depend>joy</run_depend>


### PR DESCRIPTION
safe_teleop_pr2 and safe_teleop_stage do not require safe_teleop_base at build time
