### PR TITLE
add clear_costmap service

### DIFF
--- a/safe_teleop_base/include/safe_teleop_base/safe_trajectory_planner_ros.h
+++ b/safe_teleop_base/include/safe_teleop_base/safe_trajectory_planner_ros.h
@@ -24,6 +24,7 @@
 #include <geometry_msgs/PoseStamped.h>
 #include <geometry_msgs/Twist.h>
 #include <geometry_msgs/Point.h>
+#include <std_srvs/Empty.h>
 
 #include <tf/transform_listener.h>
 
@@ -95,6 +96,8 @@ namespace safe_teleop {
 
       void cmdCallback(const geometry_msgs::Twist::ConstPtr& vel);
 
+      bool clearCostmapsService(std_srvs::Empty::Request &req, std_srvs::Empty::Response &resp);
+
       std::vector<double> loadYVels(ros::NodeHandle node);
 
       ros::NodeHandle nh_;
@@ -116,6 +119,8 @@ namespace safe_teleop {
 
       ros::Publisher cmd_pub_;
       ros::Subscriber cmd_sub_;
+
+      ros::ServiceServer clear_costmaps_srv_;
 
       boost::recursive_mutex odom_lock_;
       double max_vel_th_, min_vel_th_;

--- a/safe_teleop_base/src/safe_trajectory_planner_ros.cpp
+++ b/safe_teleop_base/src/safe_trajectory_planner_ros.cpp
@@ -50,6 +50,8 @@ namespace safe_teleop {
     geometry_msgs::Twist vel;
     cmd_pub_.publish(vel);
 
+    clear_costmaps_srv_ = private_nh.advertiseService("clear_costmaps", &SafeTrajectoryPlannerROS::clearCostmapsService, this);
+
     //we'll get the parameters for the robot radius from the costmap we're associated with
     inscribed_radius_ = costmap_ros_->getLayeredCostmap()->getInscribedRadius();
     circumscribed_radius_ = costmap_ros_->getLayeredCostmap()->getCircumscribedRadius();
@@ -293,6 +295,11 @@ namespace safe_teleop {
     }
 
     pub.publish(gui_path);
+  }
+
+  bool SafeTrajectoryPlannerROS::clearCostmapsService(std_srvs::Empty::Request &req, std_srvs::Empty::Response &resp){
+    costmap_ros_->resetLayers();
+    return true;
   }
 };
 


### PR DESCRIPTION
Sometimes we may want to clear the costmap immediately like we do in [move_base](https://github.com/ros-planning/navigation/blob/jade-devel/move_base/src/move_base.cpp#L175)
