### PR TITLE
fix install error

### DIFF
--- a/safe_teleop_pr2/CMakeLists.txt
+++ b/safe_teleop_pr2/CMakeLists.txt
@@ -4,7 +4,7 @@ project(safe_teleop_pr2)
 find_package(catkin REQUIRED COMPONENTS)
 catkin_package(CATKIN_DEPENDS safe_teleop_base pr2_teleop joy)
 
-install(DIRECTORY scripts launch config
+install(DIRECTORY launch config
   DESTINATION
   ${CATKIN_PACKAGE_SHARE_DESTINATION}
   USE_SOURCE_PERMISSIONS


### PR DESCRIPTION
script dir does not exists, this causes http://build.ros.org/job/Ibin_uT64__safe_teleop_pr2__ubuntu_trusty_amd64__binary/2/console