### PR TITLE
add param to plan safe trajectory on backwards

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,9 +14,9 @@ env:
     - JOB_PATH=/tmp/devel_job
     - ABORT_ON_TEST_FAILURE=1
   matrix:
-    - ROS_DISTRO_NAME=indigo  OS_NAME=ubuntu OS_CODE_NAME=trusty ARCH=amd64
+#    - ROS_DISTRO_NAME=indigo  OS_NAME=ubuntu OS_CODE_NAME=trusty ARCH=amd64
     - ROS_DISTRO_NAME=kinetic OS_NAME=ubuntu OS_CODE_NAME=xenial ARCH=amd64
-    - ROS_DISTRO_NAME=lunar   OS_NAME=ubuntu OS_CODE_NAME=xenial ARCH=amd64
+#    - ROS_DISTRO_NAME=lunar   OS_NAME=ubuntu OS_CODE_NAME=xenial ARCH=amd64
     - ROS_DISTRO_NAME=melodic OS_NAME=ubuntu OS_CODE_NAME=bionic ARCH=amd64
 #   matrix:
 #     allow_failures:
@@ -32,15 +32,15 @@ install:
   # run devel job for a ROS repository with the same name as this repo
   - export REPOSITORY_NAME=`basename $TRAVIS_BUILD_DIR`
   # use the code already checked out by Travis
-  - mkdir -p $JOB_PATH/catkin_workspace/src
-  - cp -R $TRAVIS_BUILD_DIR $JOB_PATH/catkin_workspace/src/
+  - mkdir -p $JOB_PATH/ws/src
+  - cp -R $TRAVIS_BUILD_DIR $JOB_PATH/ws/src/
   # generate the script to run a pre-release job for that target and repo
   - generate_prerelease_script.py https://raw.githubusercontent.com/ros-infrastructure/ros_buildfarm_config/production/index.yaml $ROS_DISTRO_NAME default $OS_NAME $OS_CODE_NAME $ARCH  --output-dir $JOB_PATH
   # run the actual job which involves Docker
   - cd $JOB_PATH; sh ./prerelease.sh -y
 script:
   # get summary of test results
-  - /tmp/catkin/bin/catkin_test_results $JOB_PATH/catkin_workspace/test_results --all
+  - /tmp/catkin/bin/catkin_test_results $JOB_PATH/ws/test_results --all
 notifications:
   email: false
 

--- a/safe_teleop_base/include/safe_teleop_base/safe_trajectory_planner_ros.h
+++ b/safe_teleop_base/include/safe_teleop_base/safe_trajectory_planner_ros.h
@@ -126,6 +126,7 @@ typedef tf::TransformListener TFListener;
 
       boost::recursive_mutex odom_lock_;
       double max_vel_th_, min_vel_th_;
+      bool safe_backwards_;
   };
 
 }

--- a/safe_teleop_base/src/safe_trajectory_planner_ros.cpp
+++ b/safe_teleop_base/src/safe_trajectory_planner_ros.cpp
@@ -78,6 +78,7 @@ namespace safe_teleop {
     private_nh.param("world_model", world_model_type, string("costmap"));
     private_nh.param("holonomic_robot", holonomic_robot, true);
     private_nh.param("dwa", dwa, true);
+    private_nh.param("safe_backwards", safe_backwards_, false);
 
     //parameters for using the freespace controller
     double min_pt_separation, max_obstacle_height, grid_resolution;
@@ -159,7 +160,9 @@ namespace safe_teleop {
   }
 
   void SafeTrajectoryPlannerROS::cmdCallback(const geometry_msgs::Twist::ConstPtr& vel) {
-    if ((vel->linear.x > 0) || (fabs(vel->linear.y) > 0)) {
+    if ((safe_backwards_  && ((fabs(vel->linear.x) > 0) || (fabs(vel->linear.y) > 0))) ||
+        (!safe_backwards_ && ((vel->linear.x > 0) || (fabs(vel->linear.y) > 0))))
+    {
       geometry_msgs::Twist safe_vel;
       if (computeVelocityCommands(vel, safe_vel)) {
         cmd_pub_.publish(safe_vel);

--- a/safe_teleop_stage/config/amcl_node.xml
+++ b/safe_teleop_stage/config/amcl_node.xml
@@ -1,0 +1,46 @@
+<launch>
+<!--
+  Example amcl configuration. Descriptions of parameters, as well as a full list of all amcl parameters, can be found at http://www.ros.org/wiki/amcl.
+-->
+<node pkg="amcl" type="amcl" name="amcl" respawn="true">
+  <remap from="scan" to="base_scan" />
+  <!-- Publish scans from best pose at a max of 10 Hz -->
+  <param name="odom_model_type" value="omni"/>
+  <param name="odom_alpha5" value="0.1"/>
+  <param name="transform_tolerance" value="0.2" />
+  <param name="gui_publish_rate" value="10.0"/>
+  <param name="laser_max_beams" value="30"/>
+  <param name="min_particles" value="500"/>
+  <param name="max_particles" value="5000"/>
+  <param name="kld_err" value="0.05"/>
+  <param name="kld_z" value="0.99"/>
+  <param name="odom_alpha1" value="0.2"/>
+  <param name="odom_alpha2" value="0.2"/>
+  <!-- translation std dev, m -->
+  <param name="odom_alpha3" value="0.8"/>
+  <param name="odom_alpha4" value="0.2"/>
+  <param name="laser_z_hit" value="0.5"/>
+  <param name="laser_z_short" value="0.05"/>
+  <param name="laser_z_max" value="0.05"/>
+  <param name="laser_z_rand" value="0.5"/>
+  <param name="laser_sigma_hit" value="0.2"/>
+  <param name="laser_lambda_short" value="0.1"/>
+  <param name="laser_lambda_short" value="0.1"/>
+  <param name="laser_model_type" value="likelihood_field"/>
+  <!-- <param name="laser_model_type" value="beam"/> -->
+  <param name="laser_likelihood_max_dist" value="2.0"/>
+  <param name="update_min_d" value="0.2"/>
+  <param name="update_min_a" value="0.5"/>
+  <param name="odom_frame_id" value="odom"/>
+  <param name="resample_interval" value="1"/>
+  <param name="transform_tolerance" value="0.1"/>
+  <param name="recovery_alpha_slow" value="0.0"/>
+  <param name="recovery_alpha_fast" value="0.0"/>
+  <param name="initial_pose_x" value="23.0" />
+  <param name="initial_pose_y" value="11.0" />
+  <param name="initial_pose_a" value="1.57" />
+  <param name="initial_cov_xx" value="0.5" />
+  <param name="initial_cov_yy" value="0.5" />
+  <param name="initial_cov_aa" value="0.1" />
+</node>
+</launch>

--- a/safe_teleop_stage/config/move_base.xml
+++ b/safe_teleop_stage/config/move_base.xml
@@ -1,0 +1,26 @@
+<launch>
+<!--
+  Example move_base configuration. Descriptions of parameters, as well as a full list of all amcl parameters, can be found at http://www.ros.org/wiki/move_base.
+-->
+  <node pkg="move_base" type="move_base" respawn="false" name="move_base_node" output="screen">
+    <param name="footprint_padding" value="0.01" />
+    <param name="controller_frequency" value="10.0" />
+    <param name="controller_patience" value="3.0" />
+
+    <param name="oscillation_timeout" value="30.0" />
+    <param name="oscillation_distance" value="0.5" />
+
+    <!--
+    <param name="base_local_planner" value="dwa_local_planner/DWAPlannerROS" />
+    -->
+
+    <rosparam file="$(find navigation_stage)/move_base_config/costmap_common_params.yaml" command="load" ns="global_costmap" />
+    <rosparam file="$(find navigation_stage)/move_base_config/costmap_common_params.yaml" command="load" ns="local_costmap" />
+    <rosparam file="$(find navigation_stage)/move_base_config/local_costmap_params.yaml" command="load" />
+    <rosparam file="$(find navigation_stage)/move_base_config/global_costmap_params.yaml" command="load" />
+    <rosparam file="$(find navigation_stage)/move_base_config/base_local_planner_params.yaml" command="load" />
+    <!--
+    <rosparam file="$(find navigation_stage)/move_base_config/dwa_local_planner_params.yaml" command="load" />
+    -->
+  </node>
+</launch>

--- a/safe_teleop_stage/launch/safe_teleop_move_base.launch
+++ b/safe_teleop_stage/launch/safe_teleop_move_base.launch
@@ -1,0 +1,36 @@
+<launch>
+  <param name="/use_sim_time" value="true"/>
+
+  <node name="map_server" pkg="map_server" type="map_server" args="$(find stage_ros)/world/willow-full.pgm 0.1" />
+  <node pkg="stage_ros" type="stageros" name="stage" args="$(find stage_ros)/world/willow-erratic.world" respawn="false" output="screen" >
+    <remap from="cmd_vel" to="base_controller/command" />
+    <param name="base_watchdog_timeout" value="0.2"/>
+  </node>
+
+  <node pkg="teleop_twist_keyboard" type="teleop_twist_keyboard.py" name="teleop_twist_keyboard"
+        launch-prefix="xterm -e" >
+    <remap from="cmd_vel" to="base_velocity" />
+  </node>
+
+  <include file="$(find safe_teleop_stage)/config/move_base.xml"/>
+  <include file="$(find safe_teleop_stage)/config/amcl_node.xml"/>
+
+  <node pkg="safe_teleop_base" type="safe_teleop_base" respawn="false" name="safe_teleop_base" output="screen">
+
+    <rosparam>
+      footprint: [[-0.125, -0.175], [-0.125, 0.175], [0.225, 0.175], [0.30, 0.0], [0.225, -0.175]]
+    </rosparam>
+    <param name="footprint_padding" value="0.05" />
+
+    <rosparam file="$(find safe_teleop_stage)/config/local_costmap.yaml" command="load" />
+    <rosparam file="$(find safe_teleop_stage)/config/safe_teleop_stage_params.yaml" command="load" />
+  </node>
+
+  <node name="cmd_vel_mux" pkg="topic_tools" type="mux" respawn="true"
+        args="base_controller/command /cmd_vel /safe_teleop_base/safe_vel">
+    <remap from="mux" to="cmd_vel_mux" />
+  </node>
+
+  <node pkg="rviz" type="rviz" name="rviz" args="-d $(find safe_teleop_stage)/launch/safe_teleop_stage.rviz" />
+</launch>
+

--- a/safe_teleop_stage/launch/safe_teleop_stage.launch
+++ b/safe_teleop_stage/launch/safe_teleop_stage.launch
@@ -1,19 +1,24 @@
 <launch>
-  <master auto="start"/>
   <param name="/use_sim_time" value="true"/>
-  <node pkg="stage" type="stageros" name="stage" args="$(find bosch_worlds)/maze.world" respawn="false" output="screen"/>
-  <node pkg="joy" type="joy_node" name="joy" />
-  <node pkg="segway_joystick" type="segway_joystick" name="segway_joystick" />
+  <node pkg="stage_ros" type="stageros" name="stage" args="$(find stage_ros)/world/willow-erratic.world" respawn="false" output="screen"/>
+
+  <node pkg="teleop_twist_keyboard" type="teleop_twist_keyboard.py" name="teleop_twist_keyboard"
+        launch-prefix="xterm -e" >
+    <remap from="cmd_vel" to="base_velocity" />
+  </node>
 
   <node pkg="safe_teleop_base" type="safe_teleop_base" respawn="false" name="safe_teleop_base" output="screen">
-    <remap from="safe_vel" to="/cmd_vel"/>
+    <remap from="~safe_vel" to="/cmd_vel"/>
 
-    <rosparam file="$(find segway_config)/footprint.yaml" command="load" />
+    <rosparam>
+      footprint: [[-0.125, -0.175], [-0.125, 0.175], [0.225, 0.175], [0.30, 0.0], [0.225, -0.175]]
+    </rosparam>
     <param name="footprint_padding" value="0.05" />
 
     <rosparam file="$(find safe_teleop_stage)/config/local_costmap.yaml" command="load" />
     <rosparam file="$(find safe_teleop_stage)/config/safe_teleop_stage_params.yaml" command="load" />
   </node>
 
+  <node pkg="rviz" type="rviz" name="rviz" args="-d $(find safe_teleop_stage)/launch/safe_teleop_stage.rviz" />
 </launch>
 

--- a/safe_teleop_stage/launch/safe_teleop_stage.rviz
+++ b/safe_teleop_stage/launch/safe_teleop_stage.rviz
@@ -106,7 +106,7 @@ Visualization Manager:
       Queue Size: 10
       Selectable: true
       Size (Pixels): 3
-      Size (m): 0.00999999978
+      Size (m): 0.100000001
       Style: Flat Squares
       Topic: /base_scan
       Unreliable: false
@@ -132,7 +132,7 @@ Visualization Manager:
       Class: rviz/Polygon
       Color: 25; 255; 0
       Enabled: true
-      Name: Polygon
+      Name: Safe Robot Footprint
       Topic: /safe_teleop_base/local_costmap/footprint
       Unreliable: false
       Value: true
@@ -141,7 +141,7 @@ Visualization Manager:
       Color Scheme: map
       Draw Behind: false
       Enabled: true
-      Name: Map
+      Name: safe Map
       Topic: /safe_teleop_base/local_costmap/costmap
       Unreliable: false
       Use Timestamp: false
@@ -190,6 +190,73 @@ Visualization Manager:
       Shaft Diameter: 0.100000001
       Shaft Length: 0.100000001
       Topic: /safe_teleop_base/user_plan
+      Unreliable: false
+      Value: true
+    - Alpha: 0.699999988
+      Class: rviz/Map
+      Color Scheme: map
+      Draw Behind: false
+      Enabled: true
+      Name: Global Map
+      Topic: /map
+      Unreliable: false
+      Use Timestamp: false
+      Value: true
+    - Alpha: 0.699999988
+      Class: rviz/Map
+      Color Scheme: costmap
+      Draw Behind: false
+      Enabled: true
+      Name: Cost Map
+      Topic: /move_base_node/local_costmap/costmap
+      Unreliable: false
+      Use Timestamp: false
+      Value: true
+    - Alpha: 1
+      Class: rviz/Polygon
+      Color: 25; 255; 0
+      Enabled: true
+      Name: Local Robot Footprint
+      Topic: /move_base_node/local_costmap/footprint
+      Unreliable: false
+      Value: true
+    - Alpha: 1
+      Buffer Length: 1
+      Class: rviz/Path
+      Color: 25; 255; 0
+      Enabled: true
+      Head Diameter: 0.300000012
+      Head Length: 0.200000003
+      Length: 0.300000012
+      Line Style: Lines
+      Line Width: 0.0299999993
+      Name: Global Path
+      Offset:
+        X: 0
+        Y: 0
+        Z: 0
+      Pose Color: 255; 85; 255
+      Pose Style: None
+      Radius: 0.0299999993
+      Shaft Diameter: 0.100000001
+      Shaft Length: 0.100000001
+      Topic: /move_base_node/TrajectoryPlannerROS/global_plan
+      Unreliable: false
+      Value: true
+    - Alpha: 1
+      Arrow Length: 0.300000012
+      Axes Length: 0.300000012
+      Axes Radius: 0.00999999978
+      Class: rviz/PoseArray
+      Color: 255; 25; 0
+      Enabled: true
+      Head Length: 0.0700000003
+      Head Radius: 0.0299999993
+      Name: PoseArray
+      Shaft Length: 0.230000004
+      Shaft Radius: 0.00999999978
+      Shape: Arrow (Flat)
+      Topic: /particlecloud
       Unreliable: false
       Value: true
   Enabled: true

--- a/safe_teleop_stage/launch/safe_teleop_stage.rviz
+++ b/safe_teleop_stage/launch/safe_teleop_stage.rviz
@@ -1,0 +1,257 @@
+Panels:
+  - Class: rviz/Displays
+    Help Height: 78
+    Name: Displays
+    Property Tree Widget:
+      Expanded:
+        - /Global Options1
+        - /Status1
+        - /Local Path1/Offset1
+      Splitter Ratio: 0.5
+    Tree Height: 565
+  - Class: rviz/Selection
+    Name: Selection
+  - Class: rviz/Tool Properties
+    Expanded:
+      - /2D Pose Estimate1
+      - /2D Nav Goal1
+      - /Publish Point1
+    Name: Tool Properties
+    Splitter Ratio: 0.588679016
+  - Class: rviz/Views
+    Expanded:
+      - /Current View1
+    Name: Views
+    Splitter Ratio: 0.5
+  - Class: rviz/Time
+    Experimental: false
+    Name: Time
+    SyncMode: 0
+    SyncSource: LaserScan
+Visualization Manager:
+  Class: ""
+  Displays:
+    - Alpha: 0.5
+      Cell Size: 1
+      Class: rviz/Grid
+      Color: 160; 160; 164
+      Enabled: true
+      Line Style:
+        Line Width: 0.0299999993
+        Value: Lines
+      Name: Grid
+      Normal Cell Count: 0
+      Offset:
+        X: 0
+        Y: 0
+        Z: 0
+      Plane: XY
+      Plane Cell Count: 10
+      Reference Frame: <Fixed Frame>
+      Value: true
+    - Angle Tolerance: 0.100000001
+      Class: rviz/Odometry
+      Covariance:
+        Orientation:
+          Alpha: 0.5
+          Color: 255; 255; 127
+          Color Style: Unique
+          Frame: Local
+          Offset: 1
+          Scale: 1
+          Value: true
+        Position:
+          Alpha: 0.300000012
+          Color: 204; 51; 204
+          Scale: 1
+          Value: true
+        Value: true
+      Enabled: true
+      Keep: 100
+      Name: Odometry
+      Position Tolerance: 0.100000001
+      Shape:
+        Alpha: 1
+        Axes Length: 1
+        Axes Radius: 0.100000001
+        Color: 255; 25; 0
+        Head Length: 0.300000012
+        Head Radius: 0.100000001
+        Shaft Length: 1
+        Shaft Radius: 0.0500000007
+        Value: Arrow
+      Topic: /base_pose_ground_truth
+      Unreliable: false
+      Value: true
+    - Alpha: 1
+      Autocompute Intensity Bounds: true
+      Autocompute Value Bounds:
+        Max Value: 10
+        Min Value: -10
+        Value: true
+      Axis: Z
+      Channel Name: intensity
+      Class: rviz/LaserScan
+      Color: 255; 255; 255
+      Color Transformer: Intensity
+      Decay Time: 0
+      Enabled: true
+      Invert Rainbow: false
+      Max Color: 255; 255; 255
+      Max Intensity: 1
+      Min Color: 0; 0; 0
+      Min Intensity: 1
+      Name: LaserScan
+      Position Transformer: XYZ
+      Queue Size: 10
+      Selectable: true
+      Size (Pixels): 3
+      Size (m): 0.00999999978
+      Style: Flat Squares
+      Topic: /base_scan
+      Unreliable: false
+      Use Fixed Frame: true
+      Use rainbow: true
+      Value: true
+    - Alpha: 1
+      Axes Length: 1
+      Axes Radius: 0.100000001
+      Class: rviz/Pose
+      Color: 255; 25; 0
+      Enabled: true
+      Head Length: 0.300000012
+      Head Radius: 0.100000001
+      Name: Pose
+      Shaft Length: 1
+      Shaft Radius: 0.0500000007
+      Shape: Arrow
+      Topic: /move_base_simple/goal
+      Unreliable: false
+      Value: true
+    - Alpha: 1
+      Class: rviz/Polygon
+      Color: 25; 255; 0
+      Enabled: true
+      Name: Polygon
+      Topic: /safe_teleop_base/local_costmap/footprint
+      Unreliable: false
+      Value: true
+    - Alpha: 0.699999988
+      Class: rviz/Map
+      Color Scheme: map
+      Draw Behind: false
+      Enabled: true
+      Name: Map
+      Topic: /safe_teleop_base/local_costmap/costmap
+      Unreliable: false
+      Use Timestamp: false
+      Value: true
+    - Alpha: 1
+      Buffer Length: 1
+      Class: rviz/Path
+      Color: 255; 0; 0
+      Enabled: true
+      Head Diameter: 0.300000012
+      Head Length: 0.200000003
+      Length: 0.300000012
+      Line Style: Lines
+      Line Width: 0.0299999993
+      Name: Local Path
+      Offset:
+        X: 0.0500000007
+        Y: 0
+        Z: 0
+      Pose Color: 255; 85; 255
+      Pose Style: None
+      Radius: 0.0299999993
+      Shaft Diameter: 0.100000001
+      Shaft Length: 0.100000001
+      Topic: /safe_teleop_base/local_plan
+      Unreliable: false
+      Value: true
+    - Alpha: 1
+      Buffer Length: 1
+      Class: rviz/Path
+      Color: 25; 255; 0
+      Enabled: true
+      Head Diameter: 0.300000012
+      Head Length: 0.200000003
+      Length: 0.300000012
+      Line Style: Lines
+      Line Width: 0.0299999993
+      Name: User Path
+      Offset:
+        X: 0
+        Y: 0
+        Z: 0
+      Pose Color: 255; 85; 255
+      Pose Style: None
+      Radius: 0.0299999993
+      Shaft Diameter: 0.100000001
+      Shaft Length: 0.100000001
+      Topic: /safe_teleop_base/user_plan
+      Unreliable: false
+      Value: true
+  Enabled: true
+  Global Options:
+    Background Color: 48; 48; 48
+    Default Light: true
+    Fixed Frame: odom
+    Frame Rate: 30
+  Name: root
+  Tools:
+    - Class: rviz/Interact
+      Hide Inactive Objects: true
+    - Class: rviz/MoveCamera
+    - Class: rviz/Select
+    - Class: rviz/FocusCamera
+    - Class: rviz/Measure
+    - Class: rviz/SetInitialPose
+      Topic: /initialpose
+    - Class: rviz/SetGoal
+      Topic: /move_base_simple/goal
+    - Class: rviz/PublishPoint
+      Single click: true
+      Topic: /clicked_point
+  Value: true
+  Views:
+    Current:
+      Class: rviz/Orbit
+      Distance: 10
+      Enable Stereo Rendering:
+        Stereo Eye Separation: 0.0599999987
+        Stereo Focal Distance: 1
+        Swap Stereo Eyes: false
+        Value: false
+      Focal Point:
+        X: 0
+        Y: 0
+        Z: 0
+      Focal Shape Fixed Size: false
+      Focal Shape Size: 0.0500000007
+      Invert Z Axis: false
+      Name: Current View
+      Near Clip Distance: 0.00999999978
+      Pitch: 1.30039775
+      Target Frame: <Fixed Frame>
+      Value: Orbit (rviz)
+      Yaw: 0.975398004
+    Saved: ~
+Window Geometry:
+  Displays:
+    collapsed: false
+  Height: 846
+  Hide Left Dock: false
+  Hide Right Dock: false
+  QMainWindow State: 000000ff00000000fd00000004000000000000016a000002c4fc0200000008fb0000001200530065006c0065006300740069006f006e00000001e10000009b0000006100fffffffb0000001e0054006f006f006c002000500072006f007000650072007400690065007302000001ed000001df00000185000000a3fb000000120056006900650077007300200054006f006f02000001df000002110000018500000122fb000000200054006f006f006c002000500072006f0070006500720074006900650073003203000002880000011d000002210000017afb000000100044006900730070006c0061007900730100000028000002c4000000d700fffffffb0000002000730065006c0065006300740069006f006e00200062007500660066006500720200000138000000aa0000023a00000294fb00000014005700690064006500530074006500720065006f02000000e6000000d2000003ee0000030bfb0000000c004b0069006e0065006300740200000186000001060000030c00000261000000010000010f000002c4fc0200000003fb0000001e0054006f006f006c002000500072006f00700065007200740069006500730100000041000000780000000000000000fb0000000a005600690065007700730100000028000002c4000000ad00fffffffb0000001200530065006c0065006300740069006f006e010000025a000000b200000000000000000000000200000490000000a9fc0100000001fb0000000a00560069006500770073030000004e00000080000002e10000019700000003000004b00000003efc0100000002fb0000000800540069006d00650100000000000004b00000030000fffffffb0000000800540069006d006501000000000000045000000000000000000000022b000002c400000004000000040000000800000008fc0000000100000002000000010000000a0054006f006f006c00730100000000ffffffff0000000000000000
+  Selection:
+    collapsed: false
+  Time:
+    collapsed: false
+  Tool Properties:
+    collapsed: false
+  Views:
+    collapsed: false
+  Width: 1200
+  X: 246
+  Y: 79


### PR DESCRIPTION
Currently, the node `safe_teleop_base` plans safe trajectory based on observation from sensors only when the input velocity is for going forwards (and left/right for holonomic robots), otherwise publishes the input velocity as it is (which is unsafe).
This PR adds option to plan safe trajectory both on forwards and backwards.
